### PR TITLE
Add more quickfixes

### DIFF
--- a/QUICKFIXES.md
+++ b/QUICKFIXES.md
@@ -9,5 +9,9 @@ This plugin contains QuickFixes for the following rules:
 - UselessParentheses
 - UseVarargs 
 - UnnecessaryConstructor
+- CallSuperInConstructor
+- FieldNamingConventions
+  - opens IntelliJs rename dialog
+- MissingSerialVersionUID
 
 Additionally, `@SuppressWarnings` can be automatically applied to members or classes for a specific rule.

--- a/src/main/java/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFix.java
+++ b/src/main/java/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFix.java
@@ -1,0 +1,39 @@
+package com.github.ybroeker.pmdidea.quickfix;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.*;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.psi.impl.PsiElementFactoryImpl;
+import org.jetbrains.annotations.NotNull;
+
+
+public class CallSuperInConstructorFix extends AbstractLocalQuickFix<PsiMethod> {
+
+    @Override
+    protected void applyFix(final @NotNull Project project, final @NotNull PsiMethod target) {
+        final PsiJavaParserFacade psiJavaParserFacade = new PsiElementFactoryImpl(project);
+
+        final PsiCodeBlock codeBlock = getCodeBlock(target);
+        if (codeBlock == null) {
+            return;
+        }
+
+        final PsiStatement superCall = psiJavaParserFacade.createStatementFromText("super();", target.getContainingFile());
+        codeBlock.addAfter(superCall, codeBlock.getFirstChild());
+        CodeStyleManager.getInstance(project).reformat(codeBlock);
+    }
+
+    private PsiCodeBlock getCodeBlock(final @NotNull PsiMethod target) {
+        for (final PsiElement child : target.getChildren()) {
+            if (child instanceof PsiCodeBlock) {
+                return (PsiCodeBlock) child;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public @NotNull String getFamilyName() {
+        return "Add super();";
+    }
+}

--- a/src/main/java/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFixFactory.java
+++ b/src/main/java/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFixFactory.java
@@ -1,0 +1,30 @@
+package com.github.ybroeker.pmdidea.quickfix;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.github.ybroeker.pmdidea.pmd.PmdRuleViolation;
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import org.jetbrains.annotations.NotNull;
+
+import static com.github.ybroeker.pmdidea.quickfix.PsiElements.findParentPsiElement;
+
+public class CallSuperInConstructorFixFactory implements QuickFixFactory {
+
+    @Override
+    public @NotNull List<LocalQuickFix> getQuickFix(@NotNull final PsiElement target, @NotNull final PmdRuleViolation violation) {
+        if (!violation.getPmdRule().getName().equals("CallSuperInConstructor")) {
+            return Collections.emptyList();
+        }
+
+        final PsiMethod method = findParentPsiElement(PsiMethod.class, target);
+        if (method == null || !method.isConstructor()) {
+            return Collections.emptyList();
+        }
+
+        return Collections.singletonList(new CallSuperInConstructorFix());
+    }
+
+}

--- a/src/main/java/com/github/ybroeker/pmdidea/quickfix/DelegateQuickFixFactory.java
+++ b/src/main/java/com/github/ybroeker/pmdidea/quickfix/DelegateQuickFixFactory.java
@@ -22,6 +22,10 @@ public final class DelegateQuickFixFactory implements QuickFixFactory {
             new UselessParenthesesFixFactory(),
             new UseVarargsFixFactory(),
             new UnnecessaryConstructorFixFactory(),
+            new FieldNamingConventionsFixFactory(),
+            new MissingSerialVersionUIDFixFactory(),
+            new CallSuperInConstructorFixFactory(),
+
             new SuppressPmdFixFactory()
     );
 

--- a/src/main/java/com/github/ybroeker/pmdidea/quickfix/FieldNamingConventionsFixFactory.java
+++ b/src/main/java/com/github/ybroeker/pmdidea/quickfix/FieldNamingConventionsFixFactory.java
@@ -1,0 +1,31 @@
+package com.github.ybroeker.pmdidea.quickfix;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.github.ybroeker.pmdidea.pmd.PmdRuleViolation;
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiIdentifier;
+import org.jetbrains.annotations.NotNull;
+
+import static com.github.ybroeker.pmdidea.quickfix.PsiElements.findParentPsiElement;
+
+public class FieldNamingConventionsFixFactory implements QuickFixFactory {
+
+    @Override
+    public @NotNull List<LocalQuickFix> getQuickFix(@NotNull final PsiElement target, @NotNull final PmdRuleViolation violation) {
+        if (!violation.getPmdRule().getName().equals("FieldNamingConventions")) {
+            return Collections.emptyList();
+        }
+
+        final PsiIdentifier member = findParentPsiElement(PsiIdentifier.class, target);
+        if (member == null) {
+            return Collections.emptyList();
+        }
+
+        //TODO:
+        return Collections.singletonList(new RenameToFix(member.getText()));
+    }
+
+}

--- a/src/main/java/com/github/ybroeker/pmdidea/quickfix/MissingSerialVersionUIDFixFactory.java
+++ b/src/main/java/com/github/ybroeker/pmdidea/quickfix/MissingSerialVersionUIDFixFactory.java
@@ -1,0 +1,28 @@
+package com.github.ybroeker.pmdidea.quickfix;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.github.ybroeker.pmdidea.pmd.PmdRuleViolation;
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.siyeh.ig.fixes.AddSerialVersionUIDFix;
+import org.jetbrains.annotations.NotNull;
+
+public class MissingSerialVersionUIDFixFactory implements QuickFixFactory {
+
+    @Override
+    public @NotNull List<LocalQuickFix> getQuickFix(@NotNull final PsiElement target, @NotNull final PmdRuleViolation violation) {
+        if (!violation.getPmdRule().getName().equals("MissingSerialVersionUID")) {
+            return Collections.emptyList();
+        }
+        final PsiClass psiClass = PsiElements.findParentPsiElement(PsiClass.class, target);
+        if (psiClass == null) {
+            return Collections.emptyList();
+        }
+
+        return Collections.singletonList(new AddSerialVersionUIDFix());
+    }
+
+}

--- a/src/main/java/com/github/ybroeker/pmdidea/quickfix/RenameToFix.java
+++ b/src/main/java/com/github/ybroeker/pmdidea/quickfix/RenameToFix.java
@@ -1,0 +1,76 @@
+package com.github.ybroeker.pmdidea.quickfix;
+
+import java.util.HashMap;
+
+import javax.swing.*;
+
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Iconable;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.refactoring.actions.RenameElementAction;
+import com.intellij.refactoring.rename.RenameHandlerRegistry;
+import icons.SpellcheckerIcons;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class RenameToFix extends AbstractLocalQuickFix<PsiNameIdentifierOwner> implements Iconable {
+
+    private final String name;
+
+    public RenameToFix(final String name) {
+        this.name = name;
+    }
+
+    @Nullable
+    protected Editor getEditor(final @NotNull PsiElement element, @NotNull final Project project) {
+        return FileEditorManager.getInstance(project).getSelectedTextEditor();
+    }
+
+    @Override
+    protected void applyFix(final @NotNull Project project, final @NotNull PsiNameIdentifierOwner psiElement) {
+        final Editor editor = getEditor(psiElement, project);
+        if (editor == null) {
+            return;
+        }
+
+        final HashMap<String, Object> map = new HashMap<>();
+        map.put(CommonDataKeys.EDITOR.getName(), editor);
+        map.put(CommonDataKeys.PSI_ELEMENT.getName(), psiElement);
+
+        final DataContext dataContext = SimpleDataContext.getSimpleContext(map, DataManager.getInstance().getDataContext(editor.getComponent()));
+        final RenameElementAction action = new RenameElementAction();
+        final AnActionEvent event = AnActionEvent.createFromAnAction(action, null, "", dataContext);
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            final Boolean selectAll = editor.getUserData(RenameHandlerRegistry.SELECT_ALL);
+            try {
+                editor.putUserData(RenameHandlerRegistry.SELECT_ALL, true);
+                action.actionPerformed(event);
+            } finally {
+                editor.putUserData(RenameHandlerRegistry.SELECT_ALL, selectAll);
+            }
+        });
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "Rename '" + name + "'";
+    }
+
+    @Override
+    public @NotNull String getFamilyName() {
+        return "Rename ...";
+    }
+
+    @Override
+    public Icon getIcon(final int flags) {
+        return SpellcheckerIcons.Spellcheck;
+    }
+}

--- a/src/test/java/com/github/ybroeker/pmdidea/ResourceUtil.java
+++ b/src/test/java/com/github/ybroeker/pmdidea/ResourceUtil.java
@@ -6,9 +6,11 @@ import java.util.stream.Collectors;
 
 public class ResourceUtil {
 
-    public static String getInputStreamAsString(final InputStream inputStream) throws IOException {
+    public static String getInputStreamAsString(final InputStream inputStream) {
         try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
             return bufferedReader.lines().collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
 
     }

--- a/src/test/java/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFixTest.java
+++ b/src/test/java/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFixTest.java
@@ -1,0 +1,47 @@
+package com.github.ybroeker.pmdidea.quickfix;
+
+import java.util.Arrays;
+
+import com.github.ybroeker.pmdidea.inspection.PsiFiles;
+import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.psi.*;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.psi.impl.PsiElementFactoryImpl;
+import com.intellij.testFramework.LightJavaCodeInsightTestCase;
+import org.junit.Assert;
+
+import static com.github.ybroeker.pmdidea.ResourceUtil.getInputStreamAsString;
+
+public class CallSuperInConstructorFixTest extends LightJavaCodeInsightTestCase {
+    String fileContent = getInputStreamAsString(MakeLocalVariableFinalFixTest.class.getResourceAsStream("CallSuperInConstructorFixTest/testCallSuperInConstructor/GivenClass.java"));
+    String expected = getInputStreamAsString(MakeParameterFinalFixTest.class.getResourceAsStream("CallSuperInConstructorFixTest/testCallSuperInConstructor/ExpectedClass.java"));
+
+    public void testCallSuperInConstructor() throws Exception {
+        final PsiFile fileFromText = PsiFileFactory.getInstance(getProject()).createFileFromText("TestClass.java", JavaFileType.INSTANCE, fileContent);
+
+        final PsiElement element = PsiFiles.getElement(fileFromText, 3, 12);
+        final PsiJavaParserFacade psiJavaParserFacade = new PsiElementFactoryImpl(getProject());
+
+        final PsiMethod target = PsiElements.findParentPsiElement(PsiMethod.class, element);
+        System.out.println(target);
+        System.out.println("target.isConstructor() = " + target.isConstructor());
+        System.out.println("target.getChildren() = " + Arrays.toString(target.getChildren()));
+        for (final PsiElement child : target.getChildren()) {
+            if (child instanceof PsiCodeBlock) {
+                final PsiStatement superCall = psiJavaParserFacade.createStatementFromText("super();", fileFromText);
+                child.addAfter(superCall, child.getFirstChild());
+                CodeStyleManager.getInstance(getProject()).reformat(child);
+                break;
+            }
+        }
+
+        //final MakeLocalVariableFinalFix quickFix = new MakeLocalVariableFinalFix("String s");
+        //quickFix.applyFix(getProject(), target);
+
+        final String actual = fileFromText.getText();
+
+
+        Assert.assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/resources/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFixTest/testCallSuperInConstructor/ExpectedClass.java
+++ b/src/test/resources/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFixTest/testCallSuperInConstructor/ExpectedClass.java
@@ -1,0 +1,7 @@
+class TestClass {
+    String test;
+    public TestClass() {
+        super();
+        test = "";
+    }
+}

--- a/src/test/resources/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFixTest/testCallSuperInConstructor/GivenClass.java
+++ b/src/test/resources/com/github/ybroeker/pmdidea/quickfix/CallSuperInConstructorFixTest/testCallSuperInConstructor/GivenClass.java
@@ -1,0 +1,6 @@
+class TestClass {
+    String test;
+    public TestClass() {
+        test = "";
+    }
+}


### PR DESCRIPTION
* CallSuperInConstructor
* FieldNamingConventions (opens rename-dialog)
* MissingSerialVersionUID

Signed-off-by: Yannick da Silva Bröker <ybroeker@techfak.uni-bielefeld.de>